### PR TITLE
Improve markdown

### DIFF
--- a/src/FormattedText/Markdown.elm
+++ b/src/FormattedText/Markdown.elm
@@ -169,9 +169,9 @@ parseInline inline =
                 |> FT.concat
                 |> FT.formatAll (Link link)
 
-        Markdown.Inline.HtmlInline _ _ _ ->
-            -- We're not parsing Html so we should never get this.
-            FT.empty
+        Markdown.Inline.HtmlInline _ _ subInlines ->
+            List.map parseInline subInlines
+                |> FT.concat
 
         Markdown.Inline.Emphasis 0 subInlines ->
             List.map parseInline subInlines
@@ -193,6 +193,6 @@ parseInline inline =
                 |> FT.formatAll Bold
                 |> FT.formatAll Italic
 
-        Markdown.Inline.Custom _ _ ->
-            -- We're not defining custom elements so we should never get this.
-            FT.empty
+        Markdown.Inline.Custom _ subInlines ->
+            List.map parseInline subInlines
+                |> FT.concat

--- a/src/FormattedText/Markdown.elm
+++ b/src/FormattedText/Markdown.elm
@@ -1,4 +1,4 @@
-module FormattedText.Markdown exposing (Block(..), Markdown(..), parse, view)
+module FormattedText.Markdown exposing (Block(..), Markdown(..), parse, view, viewInline)
 
 {-| A specific FormattedText type for inline markdown.
 
@@ -11,6 +11,7 @@ you might want to create a custom type for that structure.
 @docs Block
 @docs parse
 @docs view
+@docs viewInline
 
 -}
 
@@ -62,14 +63,88 @@ parse markdown =
         |> List.concatMap parseBlock
 
 
-{-| Render the markdown-formatted text as Html, using `strong`, `em`, `code`, and `link` tags.
+{-| Render the markdown-formatted text as Html.
+-}
+view : List Block -> List (Html msg)
+view blocks =
+    List.concatMap viewBlock blocks
+
+
+viewBlock : Block -> List (Html msg)
+viewBlock block =
+    case block of
+        ThematicBreak ->
+            [ Html.hr [] []
+            ]
+
+        Heading 1 formatted ->
+            Html.h1 [] (viewInline formatted)
+                |> List.singleton
+
+        Heading 2 formatted ->
+            Html.h2 [] (viewInline formatted)
+                |> List.singleton
+
+        Heading 3 formatted ->
+            Html.h3 [] (viewInline formatted)
+                |> List.singleton
+
+        Heading 4 formatted ->
+            Html.h4 [] (viewInline formatted)
+                |> List.singleton
+
+        Heading 5 formatted ->
+            Html.h5 [] (viewInline formatted)
+                |> List.singleton
+
+        Heading _ formatted ->
+            Html.h6 [] (viewInline formatted)
+                |> List.singleton
+
+        CodeBlock contents ->
+            Html.code [] [ Html.text contents ]
+                |> List.singleton
+                |> Html.div []
+                |> List.singleton
+
+        Paragraph formatted ->
+            Html.p [] (viewInline formatted)
+                |> List.singleton
+
+        BlockQuote blocks ->
+            List.concatMap viewBlock blocks
+                |> Html.blockquote []
+                |> List.singleton
+
+        UnOrderedList items ->
+            List.map viewItem items
+                |> Html.ul []
+                |> List.singleton
+
+        OrderedList items ->
+            List.map viewItem items
+                |> Html.ol []
+                |> List.singleton
+
+        PlainInline formatted ->
+            viewInline formatted
+
+
+viewItem : List Block -> Html msg
+viewItem blocks =
+    List.concatMap viewBlock blocks
+        |> Html.li []
+
+
+{-| If you have your own logic for rendering the markdown block elements, you
+can call this function to render the inline portions of the Markdown.
 
 If you want to render your markdown in a different way take a look at the implementation of this function
 to see how you can use `FormattedText.chunks` to do so in a simple way.
 
 -}
-view : FormattedText Markdown -> List (Html msg)
-view formatted =
+viewInline : FormattedText Markdown -> List (Html msg)
+viewInline formatted =
     FT.chunks viewChunk formatted
 
 

--- a/src/FormattedText/Markdown.elm
+++ b/src/FormattedText/Markdown.elm
@@ -102,9 +102,7 @@ viewBlock block =
                 |> List.singleton
 
         CodeBlock contents ->
-            Html.code [] [ Html.text contents ]
-                |> List.singleton
-                |> Html.div []
+            Html.pre [] [ Html.text contents ]
                 |> List.singleton
 
         Paragraph formatted ->

--- a/tests/Spec/FormattedText/Markdown.elm
+++ b/tests/Spec/FormattedText/Markdown.elm
@@ -2,20 +2,30 @@ module Spec.FormattedText.Markdown exposing (parseThenView)
 
 import Expect
 import FormattedText.Markdown as Markdown
-import Html exposing (a, code, em, strong, text)
+import Html exposing (a, code, em, h1, p, strong, text)
 import Html.Attributes exposing (href)
 import Test exposing (..)
+
+
+markdown : String
+markdown =
+    """
+# A header
+
+This **amazing** _string_ contains [markdown](https://en.wikipedia.org/wiki/Markdown) `code`
+"""
 
 
 parseThenView : Test
 parseThenView =
     test "parse then view markdown" <|
         \_ ->
-            "This **amazing** _string_ contains [markdown](https://en.wikipedia.org/wiki/Markdown) `code`"
+            markdown
                 |> Markdown.parse
-                |> Result.map Markdown.view
+                |> Markdown.view
                 |> Expect.equal
-                    (Ok
+                    [ h1 [] [ text "A header" ]
+                    , p []
                         [ text "This "
                         , strong [] [ text "amazing" ]
                         , text " "
@@ -25,4 +35,4 @@ parseThenView =
                         , text " "
                         , code [] [ text "code" ]
                         ]
-                    )
+                    ]


### PR DESCRIPTION
This improves markdown parsing and rendering so it works with block elements as well.

Block elements are not expressed as `FormattedText`, because `FormattedText` isn't really made for this (it would allow overlapping block elements, which doesn't make any sense). So instead we build a custom recursive `Block` type in which fragments of `FormattedText Markdown` are nested.