### PR TITLE
Allow exporting FormattedText as trees

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,37 @@
 sudo: false
 
-language: node_js
-node_js:
-  - '6'
+cache:
+  directories:
+    - tests/elm-stuff/build-artifacts
+    - sysconfcpus
 
+before_install:
+  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+  - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
+    if [ ! -d sysconfcpus/bin ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+    fi
 install:
-  - npm install -g elm@0.18.0 elm-test
-  - elm-package install --yes
+  - npm install -g elm@0.18.0 elm-test elm-format@exp
+  - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
+  - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
+  - chmod +x $(npm config get prefix)/bin/elm-make
+  - travis_retry elm-package install --yes
+  - cd tests
+  - npm install
+  - travis_retry elm-package install --yes
+  - cd ..
 
 script:
+  # Check if all exposed modules compile.
+  - elm-package diff
+  - elm-format --validate src
   - elm-test
+
+notifications:
+  email: false

--- a/src/AllenAlgebra.elm
+++ b/src/AllenAlgebra.elm
@@ -32,14 +32,17 @@ relation range1 range2 =
         , compare (upper range1) (upper range2)
         )
     of
+        ( EQ, _, _, EQ ) ->
+            Equal
+
         ( _, _, LT, _ ) ->
             Before
 
-        ( _, _, EQ, _ ) ->
-            Meets
-
         ( _, GT, _, _ ) ->
             After
+
+        ( _, _, EQ, _ ) ->
+            Meets
 
         ( _, EQ, _, _ ) ->
             MeetsInverse
@@ -67,9 +70,6 @@ relation range1 range2 =
 
         ( GT, _, _, GT ) ->
             OverlapsInverse
-
-        ( EQ, _, _, EQ ) ->
-            Equal
 
 
 {-| Return the lower bound of a range. Naming implies this should be 'start',

--- a/src/AllenAlgebra.elm
+++ b/src/AllenAlgebra.elm
@@ -23,13 +23,13 @@ type AllenRelation
     | Equal
 
 
-relation : { r | start : Int, end : Int } -> { p | start : Int, end : Int } -> AllenRelation
+relation : { r | start : comparable, end : comparable } -> { p | start : comparable, end : comparable } -> AllenRelation
 relation range1 range2 =
     case
-        ( compare range1.start range2.start
-        , compare range1.start range2.end
-        , compare range1.end range2.start
-        , compare range1.end range2.end
+        ( compare (lower range1) (lower range2)
+        , compare (lower range1) (upper range2)
+        , compare (upper range1) (lower range2)
+        , compare (upper range1) (upper range2)
         )
     of
         ( _, _, LT, _ ) ->
@@ -70,3 +70,19 @@ relation range1 range2 =
 
         ( EQ, _, _, EQ ) ->
             Equal
+
+
+{-| Return the lower bound of a range. Naming implies this should be 'start',
+but lets make sure.
+-}
+lower : { r | start : comparable, end : comparable } -> comparable
+lower { start, end } =
+    min start end
+
+
+{-| Return the upper bound of a range. Naming implies this should be 'start',
+but lets make sure.
+-}
+upper : { r | start : comparable, end : comparable } -> comparable
+upper { start, end } =
+    max start end

--- a/src/AllenAlgebra.elm
+++ b/src/AllenAlgebra.elm
@@ -1,0 +1,72 @@
+module AllenAlgebra exposing (..)
+
+{-| The relations defined by an allen algebra.
+
+<https://www.wikiwand.com/en/Allen's_interval_algebra#/Relations>
+
+-}
+
+
+type AllenRelation
+    = Overlaps
+    | OverlapsInverse
+    | During
+    | DuringInverse
+    | Meets
+    | MeetsInverse
+    | Starts
+    | StartsInverse
+    | Finishes
+    | FinishesInverse
+    | Before
+    | After
+    | Equal
+
+
+relation : { r | start : Int, end : Int } -> { p | start : Int, end : Int } -> AllenRelation
+relation range1 range2 =
+    case
+        ( compare range1.start range2.start
+        , compare range1.start range2.end
+        , compare range1.end range2.start
+        , compare range1.end range2.end
+        )
+    of
+        ( _, _, LT, _ ) ->
+            Before
+
+        ( _, _, EQ, _ ) ->
+            Meets
+
+        ( _, GT, _, _ ) ->
+            After
+
+        ( _, EQ, _, _ ) ->
+            MeetsInverse
+
+        ( GT, _, _, LT ) ->
+            During
+
+        ( EQ, _, _, LT ) ->
+            Starts
+
+        ( GT, _, _, EQ ) ->
+            Finishes
+
+        ( LT, _, _, GT ) ->
+            DuringInverse
+
+        ( EQ, _, _, GT ) ->
+            StartsInverse
+
+        ( LT, _, _, EQ ) ->
+            FinishesInverse
+
+        ( LT, _, _, LT ) ->
+            Overlaps
+
+        ( GT, _, _, GT ) ->
+            OverlapsInverse
+
+        ( EQ, _, _, EQ ) ->
+            Equal

--- a/src/FormattedText.elm
+++ b/src/FormattedText.elm
@@ -1,4 +1,4 @@
-module FormattedText exposing (FormattedText, Range, addRange, all, any, append, chunks, concat, cons, contains, dropLeft, dropRight, empty, endsWith, filter, foldl, foldr, formatAll, formattedText, fromChar, fromList, fromString, indexes, indices, isEmpty, join, left, length, lines, map, pad, padLeft, padRight, ranges, repeat, reverse, right, slice, split, startsWith, text, toFloat, toInt, toList, toLower, toUpper, trim, trimLeft, trimRight, unchunk, uncons, words)
+module FormattedText exposing (FormattedText, Range, addRange, all, any, append, chunks, concat, cons, contains, dropLeft, dropRight, empty, endsWith, filter, foldl, foldr, formatAll, formattedText, fromChar, fromList, fromString, indexes, indices, isEmpty, join, left, length, lines, map, pad, padLeft, padRight, ranges, repeat, reverse, right, slice, split, startsWith, text, toFloat, toInt, toList, toLower, toUpper, trees, trim, trimLeft, trimRight, unchunk, uncons, words)
 
 {-| A type representing text with formatting.
 
@@ -19,6 +19,7 @@ module FormattedText exposing (FormattedText, Range, addRange, all, any, append,
 
 @docs text
 @docs chunks
+@docs trees
 
 
 ## String-like operations for FormattedText
@@ -84,6 +85,7 @@ If you feel the need to do this, please create an issue on our Github repo with 
 import FormattedText.Internal as Internal
 import FormattedText.Regex
 import FormattedText.Shared as Shared
+import FormattedText.Tree
 import Regex exposing (Regex)
 
 
@@ -794,3 +796,12 @@ unchunk chunks =
     chunks
         |> List.map formatChunk
         |> concat
+
+
+{-| Certain operations, like rendering to Html, can be hard to perform with FormattedText directly.
+`trees` creates a markup tree from a FormattedText.
+You can pass it a function for generating a text leaf of the tree, and a function to generate a markup node of the tree.
+-}
+trees : (String -> tree) -> (markup -> List tree -> tree) -> FormattedText markup -> List tree
+trees =
+    FormattedText.Tree.trees

--- a/src/FormattedText/Tree.elm
+++ b/src/FormattedText/Tree.elm
@@ -1,0 +1,138 @@
+module FormattedText.Tree exposing (..)
+
+import AllenAlgebra
+import FormattedText.Internal as Internal exposing (FormattedText)
+
+
+type Tree a
+    = Tree a (Forest a)
+
+
+type alias Forest a =
+    List (Tree a)
+
+
+{-| A simplification of the allen relations, keeping only information we're
+interested in.
+-}
+type RangeRelation
+    = Equal
+    | Contains
+    | During
+    | Before
+    | After
+    | OverlapsLeft
+    | OverlapsRight
+
+
+relation : Range a -> Range b -> RangeRelation
+relation range1 range2 =
+    case AllenAlgebra.relation range1 range2 of
+        AllenAlgebra.Overlaps ->
+            OverlapsLeft
+
+        AllenAlgebra.OverlapsInverse ->
+            OverlapsRight
+
+        AllenAlgebra.During ->
+            During
+
+        AllenAlgebra.DuringInverse ->
+            Contains
+
+        AllenAlgebra.Meets ->
+            Before
+
+        AllenAlgebra.MeetsInverse ->
+            After
+
+        AllenAlgebra.Starts ->
+            During
+
+        AllenAlgebra.StartsInverse ->
+            Contains
+
+        AllenAlgebra.Finishes ->
+            During
+
+        AllenAlgebra.FinishesInverse ->
+            Contains
+
+        AllenAlgebra.Before ->
+            Before
+
+        AllenAlgebra.After ->
+            After
+
+        AllenAlgebra.Equal ->
+            Equal
+
+
+type alias Range tag =
+    { tag : tag
+    , start : Int
+    , end : Int
+    }
+
+
+addTree : Tree (Range tag) -> Forest (Range tag) -> Forest (Range tag)
+addTree (Tree newRange newChildren) forest =
+    case forest of
+        [] ->
+            [ Tree newRange newChildren ]
+
+        (Tree headRange headChildren) :: rest ->
+            case relation newRange headRange of
+                Equal ->
+                    Tree newRange (addTree (Tree headRange headChildren) newChildren) :: rest
+
+                Contains ->
+                    Tree newRange (addTree (Tree headRange headChildren) newChildren) :: rest
+
+                During ->
+                    Tree headRange (addTree (Tree newRange newChildren) headChildren) :: rest
+
+                Before ->
+                    Tree newRange newChildren :: Tree headRange headChildren :: rest
+
+                After ->
+                    Tree headRange headChildren :: addTree (Tree newRange newChildren) rest
+
+                OverlapsLeft ->
+                    let
+                        ( outsideHead, insideHead ) =
+                            splitOn headRange.start newRange
+                    in
+                    Tree outsideHead []
+                        :: Tree headRange (addTree (Tree insideHead []) headChildren)
+                        :: rest
+                        |> (\newForest -> List.foldl addTree newForest newChildren)
+
+                OverlapsRight ->
+                    let
+                        ( insideHead, outsideHead ) =
+                            splitOn headRange.end newRange
+                    in
+                    Tree headRange (addTree (Tree insideHead []) headChildren)
+                        :: Tree outsideHead []
+                        :: rest
+                        |> (\newForest -> List.foldl addTree newForest newChildren)
+
+
+splitOn : Int -> Range tag -> ( Range tag, Range tag )
+splitOn n range =
+    ( { range | end = n }
+    , { range | start = n }
+    )
+
+
+trees : (String -> tree) -> (markup -> List tree -> tree) -> FormattedText markup -> List tree
+trees leaf node formatted =
+    Debug.crash "TODO"
+
+
+rangeForest : FormattedText markup -> Forest (Range markup)
+rangeForest formatted =
+    Internal.ranges formatted
+        |> List.map (\range -> Tree range [])
+        |> List.foldl addTree []

--- a/src/Parser.elm
+++ b/src/Parser.elm
@@ -1,0 +1,31 @@
+module Parser exposing (Bite, Parser, parse)
+
+{-| Not really a proper parsing library, but nevertheless a useful abstraction
+for the implementation of FormattedText.Tree.
+-}
+
+
+type alias Parser output =
+    { bites : List (Bite output)
+    , digestRemainder : String -> output
+    }
+
+
+type alias Bite output =
+    { chars : Int
+    , digest : String -> output
+    }
+
+
+parse : String -> Parser output -> List output
+parse text parser =
+    List.foldl takeBite ( [], text ) parser.bites
+        |> (\( result, remainder ) -> parser.digestRemainder remainder :: result)
+        |> List.reverse
+
+
+takeBite : Bite output -> ( List output, String ) -> ( List output, String )
+takeBite { chars, digest } ( output, text ) =
+    ( digest (String.left chars text) :: output
+    , String.dropLeft chars text
+    )

--- a/tests/Spec/AllenAlgebra.elm
+++ b/tests/Spec/AllenAlgebra.elm
@@ -1,0 +1,23 @@
+module Spec.AllenAlgebra exposing (..)
+
+import AllenAlgebra
+import Expect
+import Fuzz exposing (Fuzzer)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "AllenAlgebra"
+        [ fuzz2 Fuzz.int Fuzz.int "An Allen Algebra compacts into an Order when its ranges are points." <|
+            \x y ->
+                case compare x y of
+                    LT ->
+                        Expect.equal AllenAlgebra.Before (AllenAlgebra.relation { start = x, end = x } { start = y, end = y })
+
+                    EQ ->
+                        Expect.equal AllenAlgebra.Equal (AllenAlgebra.relation { start = x, end = x } { start = y, end = y })
+
+                    GT ->
+                        Expect.equal AllenAlgebra.After (AllenAlgebra.relation { start = x, end = x } { start = y, end = y })
+        ]

--- a/tests/Spec/FormattedText.elm
+++ b/tests/Spec/FormattedText.elm
@@ -706,7 +706,7 @@ repetitiveFTextElement =
 assertPartAt : FormattedText Markup -> FormattedText Markup -> Int -> Expectation
 assertPartAt part whole index =
     FT.slice index (index + FT.length part) whole
-        |> Expect.equal part
+        |> equals part
 
 
 assertPartNotAt : FormattedText Markup -> FormattedText Markup -> Int -> Expectation

--- a/tests/Spec/FormattedText/Tree.elm
+++ b/tests/Spec/FormattedText/Tree.elm
@@ -1,9 +1,75 @@
 module Spec.FormattedText.Tree exposing (..)
 
+import Expect
 import FormattedText as FT
 import FormattedText.Fuzz
 import FormattedText.Tree
+import Fuzz
 import Test exposing (..)
+
+
+type Tree markup
+    = Leaf String
+    | Node markup (List (Tree markup))
+
+
+suite : Test
+suite =
+    describe "FormattedText.Tree"
+        [ describe "mapAccumL"
+            [ fuzz (Fuzz.list Fuzz.int) "does as map does" <|
+                \ints ->
+                    FormattedText.Tree.mapAccumL (\n () -> ( (), n * 2 )) () ints
+                        |> Tuple.second
+                        |> Expect.equal (List.map (\n -> n * 2) ints)
+            , fuzz (Fuzz.list Fuzz.unit) "passes through an accumumlator" <|
+                \units ->
+                    FormattedText.Tree.mapAccumL (\() acc -> ( acc + 1, acc )) 1 units
+                        |> Tuple.second
+                        |> Expect.equal (List.range 1 (List.length units))
+            ]
+        , test "creates nice tree for nested markup" <|
+            \_ ->
+                FT.concat
+                    [ FT.fromString "Nest "
+                    , FT.concat
+                        [ FT.fromString "Yellow"
+                            |> FT.formatAll FormattedText.Fuzz.Yellow
+                        , FT.fromString " inside of Red"
+                        ]
+                        |> FT.formatAll FormattedText.Fuzz.Red
+                    , FT.fromString "."
+                    ]
+                    |> FormattedText.Tree.trees identity toXmlNode
+                    |> String.concat
+                    |> Expect.equal "Nest <red><yellow>Yellow</yellow> inside of Red</red>."
+        , fuzz FormattedText.Fuzz.formattedText "trees and fromTrees are duals" <|
+            \formatted ->
+                FormattedText.Tree.trees Leaf Node formatted
+                    |> fromTrees
+                    |> FormattedText.Fuzz.equals formatted
+        ]
+
+
+toXmlNode : FormattedText.Fuzz.Markup -> List String -> String
+toXmlNode markup children =
+    "<" ++ tag markup ++ ">" ++ String.concat children ++ "</" ++ tag markup ++ ">"
+
+
+tag : FormattedText.Fuzz.Markup -> String
+tag markup =
+    case markup of
+        FormattedText.Fuzz.Red ->
+            "red"
+
+        FormattedText.Fuzz.Blue ->
+            "blue"
+
+        FormattedText.Fuzz.Green ->
+            "green"
+
+        FormattedText.Fuzz.Yellow ->
+            "yellow"
 
 
 dual : Test
@@ -16,6 +82,27 @@ dual =
                 |> FormattedText.Fuzz.equals formatted
 
 
+fromTrees : List (Tree markup) -> FT.FormattedText markup
+fromTrees trees =
+    List.map fromTree trees
+        |> FT.concat
+
+
+fromTree : Tree markup -> FT.FormattedText markup
+fromTree tree =
+    case tree of
+        Leaf text ->
+            FT.fromString text
+
+        Node markup subtrees ->
+            FT.formatAll markup (fromTrees subtrees)
+
+
 toRanges : FormattedText.Tree.Tree (FormattedText.Tree.Range markup) -> List (FormattedText.Tree.Range markup)
 toRanges (FormattedText.Tree.Tree range children) =
     range :: List.concatMap toRanges children
+
+
+nonEmptyString : Fuzz.Fuzzer String
+nonEmptyString =
+    Fuzz.map2 String.cons Fuzz.char Fuzz.string

--- a/tests/Spec/FormattedText/Tree.elm
+++ b/tests/Spec/FormattedText/Tree.elm
@@ -1,0 +1,21 @@
+module Spec.FormattedText.Tree exposing (..)
+
+import FormattedText as FT
+import FormattedText.Fuzz
+import FormattedText.Tree
+import Test exposing (..)
+
+
+dual : Test
+dual =
+    fuzz FormattedText.Fuzz.formattedText "rangeForest doesn't mangle ranges" <|
+        \formatted ->
+            FormattedText.Tree.rangeForest formatted
+                |> List.concatMap toRanges
+                |> List.foldl FT.addRange (FT.fromString (FT.text formatted))
+                |> FormattedText.Fuzz.equals formatted
+
+
+toRanges : FormattedText.Tree.Tree (FormattedText.Tree.Range markup) -> List (FormattedText.Tree.Range markup)
+toRanges (FormattedText.Tree.Tree range children) =
+    range :: List.concatMap toRanges children

--- a/tests/Spec/Parser.elm
+++ b/tests/Spec/Parser.elm
@@ -1,0 +1,27 @@
+module Spec.Parser exposing (..)
+
+import Expect
+import Fuzz exposing (Fuzzer)
+import Parser
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "Parser"
+        [ fuzz2 (parser (Fuzz.constant identity)) Fuzz.string "Parser an entire string" <|
+            \parser string ->
+                Parser.parse string parser
+                    |> String.concat
+                    |> Expect.equal string
+        ]
+
+
+parser : Fuzzer (String -> a) -> Fuzzer (Parser.Parser a)
+parser digest =
+    Fuzz.map2 Parser.Parser (Fuzz.list (bite digest)) digest
+
+
+bite : Fuzzer (String -> a) -> Fuzzer (Parser.Bite a)
+bite digest =
+    Fuzz.map2 Parser.Bite (Fuzz.intRange 0 10) digest


### PR DESCRIPTION
This can be used to generate nicer Html or Markdown syntax for formatted texts than the current `chunks` export function allows.