### PR TITLE
Fix tree duality problem

### DIFF
--- a/src/FormattedText/Tree.elm
+++ b/src/FormattedText/Tree.elm
@@ -112,8 +112,7 @@ addTree (Tree newRange newChildren) forest =
                             splitOn headRange.start newRange
                     in
                     Tree outsideHead []
-                        :: Tree headRange (addTree (Tree insideHead []) headChildren)
-                        :: rest
+                        :: addTree (Tree headRange (addTree (Tree insideHead []) headChildren)) rest
                         |> (\newForest -> List.foldl addTree newForest newChildren)
 
                 OverlapsRight ->
@@ -122,8 +121,7 @@ addTree (Tree newRange newChildren) forest =
                             splitOn headRange.end newRange
                     in
                     Tree headRange (addTree (Tree insideHead []) headChildren)
-                        :: Tree outsideHead []
-                        :: rest
+                        :: addTree (Tree outsideHead []) rest
                         |> (\newForest -> List.foldl addTree newForest newChildren)
 
 

--- a/src/Parser.elm
+++ b/src/Parser.elm
@@ -20,7 +20,12 @@ type alias Bite output =
 parse : String -> Parser output -> List output
 parse text parser =
     List.foldl takeBite ( [], text ) parser.bites
-        |> (\( result, remainder ) -> parser.digestRemainder remainder :: result)
+        |> (\( result, remainder ) ->
+                if remainder == "" then
+                    result
+                else
+                    parser.digestRemainder remainder :: result
+           )
         |> List.reverse
 
 

--- a/tests/Spec/FormattedText/Tree.elm
+++ b/tests/Spec/FormattedText/Tree.elm
@@ -64,6 +64,18 @@ suite =
                 FormattedText.Tree.trees Leaf Node formatted
                     |> fromTrees
                     |> FormattedText.Fuzz.equals formatted
+        , test "trees and fromTrees are duals (known hard case)" <|
+            \_ ->
+                let
+                    formatted =
+                        FT.fromString "abcd"
+                            |> FT.addRange { tag = FormattedText.Fuzz.Red, start = 1, end = 3 }
+                            |> FT.addRange { tag = FormattedText.Fuzz.Green, start = 1, end = 3 }
+                            |> FT.addRange { tag = FormattedText.Fuzz.Blue, start = 0, end = 2 }
+                in
+                FormattedText.Tree.trees Leaf Node formatted
+                    |> fromTrees
+                    |> FormattedText.Fuzz.equals formatted
         ]
 
 


### PR DESCRIPTION
A test in a dependent library brought to light a bug in the implementation of the `trees` function. This PR introduces a test for that bug and a subsequent fix.