### PR TITLE
Fix list parsing

### DIFF
--- a/src/FormattedText/Markdown.elm
+++ b/src/FormattedText/Markdown.elm
@@ -214,7 +214,7 @@ parseBlock block =
                 |> List.singleton
 
         Markdown.Block.List { type_ } items ->
-            List.concatMap (List.map parseBlock) items
+            List.map (List.concatMap parseBlock) items
                 |> (case type_ of
                         Markdown.Block.Unordered ->
                             UnOrderedList

--- a/tests/Spec/FormattedText/Markdown.elm
+++ b/tests/Spec/FormattedText/Markdown.elm
@@ -1,8 +1,14 @@
-module Spec.FormattedText.Markdown exposing (parseInlineThenViewInline, parseThenView)
+module Spec.FormattedText.Markdown
+    exposing
+        ( parseInlineThenViewInline
+        , parseList
+        , parseThenView
+        )
 
 import Expect
-import FormattedText.Markdown as Markdown
-import Html exposing (a, code, em, h1, p, strong, text)
+import FormattedText
+import FormattedText.Markdown as Markdown exposing (..)
+import Html exposing (a, code, em, h1, li, p, strong, text, ul)
 import Html.Attributes exposing (href)
 import Test exposing (..)
 
@@ -34,6 +40,37 @@ parseThenView =
                         , a [ href "https://en.wikipedia.org/wiki/Markdown" ] [ text "markdown" ]
                         , text " "
                         , code [] [ text "code" ]
+                        ]
+                    ]
+
+
+markdownList : String
+markdownList =
+    """* this
+  * is nested"""
+
+
+
+-- * is nested
+
+
+parseList : Test
+parseList =
+    test "parse list" <|
+        \_ ->
+            markdownList
+                |> Markdown.parse
+                |> Expect.equal
+                    [ UnOrderedList
+                        [ [ PlainInline
+                                (FormattedText.fromString "this")
+                          ]
+                        , [ UnOrderedList
+                                [ [ PlainInline
+                                        (FormattedText.fromString "is nested")
+                                  ]
+                                ]
+                          ]
                         ]
                     ]
 

--- a/tests/Spec/FormattedText/Markdown.elm
+++ b/tests/Spec/FormattedText/Markdown.elm
@@ -47,7 +47,9 @@ parseThenView =
 markdownList : String
 markdownList =
     """* this
-  * is nested"""
+  * is nested
+  * foo
+* bar"""
 
 
 
@@ -64,12 +66,17 @@ parseList =
                     [ UnOrderedList
                         [ [ PlainInline
                                 (FormattedText.fromString "this")
-                          ]
-                        , [ UnOrderedList
+                          , UnOrderedList
                                 [ [ PlainInline
                                         (FormattedText.fromString "is nested")
                                   ]
+                                , [ PlainInline
+                                        (FormattedText.fromString "foo")
+                                  ]
                                 ]
+                          ]
+                        , [ PlainInline
+                                (FormattedText.fromString "bar")
                           ]
                         ]
                     ]


### PR DESCRIPTION
The current implementation of lists leads to broken html.


### Currently `parse >> view` produces

```html
<ul>
  <li>first item</li>
  <li>second item</li> <!-- This shouldn't be closed -->
  <li>
    <ul>
      <li>second item first subitem</li>
      <li>second item second subitem</li> <!-- This shouldn't be closed -->
      <li>
        <ul>
          <li>second item second subitem first sub-subitem</li>
          <li>second item second subitem second sub-subitem</li>
          <li>second item second subitem third sub-subitem</li>
        </ul>
      </li>
      <li>second item third subitem</li>
    </ul>
  </li>
  <li>third item</li>
</ul>
```

### It should produce this though
```html
<ul>
  <li>first item</li>
  <li>second item     
  <!-- Look, the closing </li> tag is not placed here! -->
    <ul>
      <li>second item first subitem</li>
      <li>second item second subitem
      <!-- Same for the second nested unordered list! -->
        <ul>
          <li>second item second subitem first sub-subitem</li>
          <li>second item second subitem second sub-subitem</li>
          <li>second item second subitem third sub-subitem</li>
        </ul>
      </li> <!-- Closing </li> tag for the li that
                  contains the third unordered list -->
      <li>second item third subitem</li>
    </ul>
  <!-- Here is the closing </li> tag -->
  </li>
  <li>third item</li>
</ul>
```
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul#Nesting_list