### PR TITLE
Remove `toString`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
       cd ..;
     fi
 install:
-  - npm install -g elm@0.18.0 elm-test elm-format@exp
+  - npm install -g elm@0.18.0 elm-test elm-format@0.7.0-exp
   - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
   - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
   - chmod +x $(npm config get prefix)/bin/elm-make

--- a/src/FormattedText.elm
+++ b/src/FormattedText.elm
@@ -414,7 +414,7 @@ indexes part whole =
     in
     String.indexes (text part) (text whole)
         -- We found all matching substrings, but they might have different formatting.
-        |> List.filter (partAtIndex >> equal part)
+        |> List.filter (partAtIndex >> Internal.equal part)
 
 
 {-| Alias of `indexes`.
@@ -442,7 +442,7 @@ Equivalent of `String.startsWith`.
 -}
 startsWith : FormattedText markup -> FormattedText markup -> Bool
 startsWith start whole =
-    equal start (left (length start) whole)
+    Internal.equal start (left (length start) whole)
 
 
 {-| Check if a FormattedText end with a sub-FormattedText.
@@ -451,31 +451,7 @@ Equivalent of `String.endsWith`.
 -}
 endsWith : FormattedText markup -> FormattedText markup -> Bool
 endsWith end whole =
-    equal end (right (length end) whole)
-
-
-equal : FormattedText markup -> FormattedText markup -> Bool
-equal formattedA formattedB =
-    let
-        textEqual : Bool
-        textEqual =
-            text formattedA == text formattedB
-
-        rangesEqual : Bool
-        rangesEqual =
-            sortRanges (ranges formattedA) == sortRanges (ranges formattedB)
-
-        sortRanges : List (Range markup) -> List (Range markup)
-        sortRanges ranges =
-            List.sortBy hashRange ranges
-
-        hashRange : Range markup -> String
-        hashRange { start, end, tag } =
-            -- Because we have no information about what tag might be,
-            -- stringifying it is our only resort for allowing us to compare it.
-            toString ( start, end, tag )
-    in
-    textEqual && rangesEqual
+    Internal.equal end (right (length end) whole)
 
 
 {-| Parse the FormattedText as an Int.

--- a/src/FormattedText/Fuzz.elm
+++ b/src/FormattedText/Fuzz.elm
@@ -16,6 +16,7 @@ import Compare
 import EqualCheck exposing (EqualCheck)
 import Expect exposing (Expectation)
 import FormattedText as FT exposing (FormattedText, Range)
+import FormattedText.Internal as Internal
 import Fuzz exposing (..)
 
 
@@ -133,18 +134,5 @@ Use this in tests for running assertions against your formatted text.
 -}
 equals : EqualCheck (FormattedText markup)
 equals formattedA formattedB =
-    formattedB
-        |> Expect.all
-            [ FT.ranges >> equalRanges (FT.ranges formattedA)
-            , FT.text >> Expect.equal (FT.text formattedA)
-            ]
-
-
-equalRanges : EqualCheck (List (Range markup))
-equalRanges rangesA rangesB =
-    let
-        orderRanges : Compare.Comparator (Range markup)
-        orderRanges =
-            Compare.concat [ Compare.by .start, Compare.by (.tag >> toString) ]
-    in
-    EqualCheck.listContents orderRanges rangesA rangesB
+    Internal.equal formattedA formattedB
+        |> Expect.true "Expected the formatted text to be the same."

--- a/src/FormattedText/Fuzz.elm
+++ b/src/FormattedText/Fuzz.elm
@@ -12,7 +12,6 @@ This can be used to test code that makes use of FormattedText.
 
 -}
 
-import Compare
 import EqualCheck exposing (EqualCheck)
 import Expect exposing (Expectation)
 import FormattedText as FT exposing (FormattedText, Range)

--- a/src/FormattedText/Internal.elm
+++ b/src/FormattedText/Internal.elm
@@ -1,4 +1,4 @@
-module FormattedText.Internal exposing (FormattedText, addRange, fromString, overlap, ranges, text)
+module FormattedText.Internal exposing (FormattedText, addRange, compareRanges, equal, fromString, overlap, ranges, text)
 
 {-| These types and functions are pulled from `Nri.FormattedText` to ensure constraints on the `FormattedText` type are always kept.
 -}
@@ -101,3 +101,72 @@ overlap a b =
 ranges : FormattedText tag -> List (Range tag)
 ranges (FormattedText _ ranges) =
     ranges
+
+
+{-| -}
+equal : FormattedText markup -> FormattedText markup -> Bool
+equal formattedA formattedB =
+    let
+        textEqual : Bool
+        textEqual =
+            text formattedA == text formattedB
+
+        rangesEqual : Bool
+        rangesEqual =
+            sortRanges (ranges formattedA) == sortRanges (ranges formattedB)
+
+        sortRanges : List (Range markup) -> List (Range markup)
+        sortRanges ranges =
+            List.sortWith order ranges
+
+        order : Range markup -> Range markup -> Order
+        order =
+            compareRanges (ranges formattedA) (ranges formattedB)
+    in
+    textEqual && rangesEqual
+
+
+{-| -}
+compareRanges : List (Range tag) -> List (Range tag) -> Range tag -> Range tag -> Order
+compareRanges rangesA rangesB =
+    let
+        tagOrders : List ( Int, tag )
+        tagOrders =
+            (rangesA ++ rangesB)
+                |> List.foldl onlyUnique []
+                |> List.indexedMap (,)
+
+        onlyUnique : Range tag -> List tag -> List tag
+        onlyUnique range unique =
+            if List.member range.tag unique then
+                unique
+            else
+                range.tag :: unique
+
+        getTagOrder : tag -> Int
+        getTagOrder searched =
+            tagOrders
+                |> List.filter (\( index, tag ) -> tag == searched)
+                |> List.head
+                |> Maybe.map Tuple.first
+                -- Doesn't happen
+                |> Maybe.withDefault -1
+
+        ordering : Range tag -> Range tag -> Order
+        ordering a b =
+            if a.start < b.start then
+                LT
+            else if a.start > b.start then
+                GT
+            else if a.end < b.end then
+                LT
+            else if a.end > b.end then
+                GT
+            else if getTagOrder a.tag < getTagOrder b.tag then
+                LT
+            else if getTagOrder a.tag > getTagOrder b.tag then
+                GT
+            else
+                EQ
+    in
+    ordering

--- a/src/FormattedText/Internal.elm
+++ b/src/FormattedText/Internal.elm
@@ -1,4 +1,4 @@
-module FormattedText.Internal exposing (FormattedText, addRange, compareRanges, equal, fromString, overlap, ranges, text)
+module FormattedText.Internal exposing (FormattedText, addRange, compareRanges, equal, equalRanges, fromString, overlap, ranges, text)
 
 {-| These types and functions are pulled from `Nri.FormattedText` to ensure constraints on the `FormattedText` type are always kept.
 -}
@@ -113,17 +113,24 @@ equal formattedA formattedB =
 
         rangesEqual : Bool
         rangesEqual =
-            sortRanges (ranges formattedA) == sortRanges (ranges formattedB)
-
-        sortRanges : List (Range markup) -> List (Range markup)
-        sortRanges ranges =
-            List.sortWith order ranges
-
-        order : Range markup -> Range markup -> Order
-        order =
-            compareRanges (ranges formattedA) (ranges formattedB)
+            equalRanges (ranges formattedA) (ranges formattedB)
     in
     textEqual && rangesEqual
+
+
+{-| -}
+equalRanges : List (Range tag) -> List (Range tag) -> Bool
+equalRanges rangesA rangesB =
+    let
+        order : Range tag -> Range tag -> Order
+        order =
+            compareRanges rangesA rangesB
+
+        sortRanges : List (Range tag) -> List (Range tag)
+        sortRanges ranges =
+            List.sortWith order ranges
+    in
+    sortRanges rangesA == sortRanges rangesB
 
 
 {-| -}

--- a/src/FormattedText/Internal.elm
+++ b/src/FormattedText/Internal.elm
@@ -1,4 +1,4 @@
-module FormattedText.Internal exposing (FormattedText, addRange, compareRanges, equal, equalRanges, fromString, overlap, ranges, text)
+module FormattedText.Internal exposing (FormattedText, addRange, equal, equalRanges, fromString, overlap, ranges, text)
 
 {-| These types and functions are pulled from `Nri.FormattedText` to ensure constraints on the `FormattedText` type are always kept.
 -}
@@ -133,7 +133,6 @@ equalRanges rangesA rangesB =
     sortRanges rangesA == sortRanges rangesB
 
 
-{-| -}
 compareRanges : List (Range tag) -> List (Range tag) -> Range tag -> Range tag -> Order
 compareRanges rangesA rangesB =
     let

--- a/tests/Spec/FormattedText/Internal.elm
+++ b/tests/Spec/FormattedText/Internal.elm
@@ -55,6 +55,7 @@ overlapTests =
 type Tag
     = First
     | Second
+    | Third
 
 
 equalTests : Test
@@ -73,7 +74,7 @@ equalTests =
             [ range First 0 4, range First 6 8 ]
 
         rangesA2 =
-            [ range First 1 2, range First 3 5 ]
+            [ range First 1 2, range First 3 5, range Third 2 3 ]
 
         rangesB1 =
             [ range Second 0 4, range Second 6 8 ]

--- a/tests/Spec/FormattedText/Internal.elm
+++ b/tests/Spec/FormattedText/Internal.elm
@@ -1,6 +1,7 @@
-module Spec.FormattedText.Internal exposing (overlapTests)
+module Spec.FormattedText.Internal exposing (equalTests, overlapTests)
 
 import Expect exposing (Expectation)
+import FormattedText as FT
 import FormattedText.Internal as Internal exposing (overlap)
 import Test exposing (..)
 
@@ -44,4 +45,54 @@ overlapTests =
             \_ ->
                 overlap { tag = "a", start = 2, end = 4 } { tag = "a", start = 2, end = 4 }
                     |> Expect.equal True
+        ]
+
+
+
+-- EQUAL TESTS
+
+
+type Tag
+    = First
+    | Second
+
+
+equalTests : Test
+equalTests =
+    let
+        text1 =
+            "abcdefghij 111"
+
+        text2 =
+            "abcdefghij 222"
+
+        range tag start end =
+            { tag = tag, start = start, end = end }
+
+        rangesA1 =
+            [ range First 0 4, range First 6 8 ]
+
+        rangesA2 =
+            [ range First 1 2, range First 3 5 ]
+
+        rangesB1 =
+            [ range Second 0 4, range Second 6 8 ]
+    in
+    describe "FormattedText#compareRanges"
+        [ test "when formats are truely equal" <|
+            \_ ->
+                Internal.equal (FT.formattedText text1 rangesA1) (FT.formattedText text1 rangesA1)
+                    |> Expect.equal True
+        , test "when formats are equal in ranges, but not in text" <|
+            \_ ->
+                Internal.equal (FT.formattedText text1 rangesA1) (FT.formattedText text2 rangesA1)
+                    |> Expect.equal False
+        , test "when formats are equal in text, but not in ranges " <|
+            \_ ->
+                Internal.equal (FT.formattedText text1 rangesA1) (FT.formattedText text1 rangesA2)
+                    |> Expect.equal False
+        , test "when formats are equal in text, and ranges are equal in position, but not tag" <|
+            \_ ->
+                Internal.equal (FT.formattedText text1 rangesA1) (FT.formattedText text1 rangesB1)
+                    |> Expect.equal False
         ]

--- a/tests/Util.elm
+++ b/tests/Util.elm
@@ -6,10 +6,10 @@ Some of these methods might fit nicely into libraries.
 
 -}
 
-import Compare
 import EqualCheck exposing (EqualCheck)
 import Expect exposing (Expectation)
 import FormattedText as FT exposing (FormattedText, Range)
+import FormattedText.Internal as Internal
 import Fuzz exposing (Fuzzer, int, intRange, list, string)
 
 
@@ -25,12 +25,8 @@ just expectation maybe =
 
 equalRanges : EqualCheck (List (Range markup))
 equalRanges rangesA rangesB =
-    let
-        orderRanges : Compare.Comparator (Range markup)
-        orderRanges =
-            Compare.concat [ Compare.by .start, Compare.by (.tag >> toString) ]
-    in
-    EqualCheck.listContents orderRanges rangesA rangesB
+    Internal.equalRanges rangesA rangesB
+        |> Expect.true "Expected ranges to be true."
 
 
 rangesDontOverlap : List (Range markup) -> Expectation


### PR DESCRIPTION
In preparation for Elm 0.19, we're removing the use of `toString`.